### PR TITLE
Closes #17 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "useTabs": false,
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,55 +1,75 @@
 [![npm](https://img.shields.io/npm/v/nativescript-image-cache-it.svg)](https://www.npmjs.com/package/nativescript-image-cache-it)
 [![npm](https://img.shields.io/npm/dt/nativescript-image-cache-it.svg?label=npm%20downloads)](https://www.npmjs.com/package/nativescript-image-cache-it)
 [![Build Status](https://travis-ci.org/triniwiz/nativescript-image-cache-it.svg?branch=master)](https://travis-ci.org/triniwiz/nativescript-image-cache-it)
-# Image-Cache-It
-[*Picasso*](http://square.github.io/picasso/) - *Android*
 
-[*SDWebImage*](https://github.com/rs/SDWebImage/) - *IOS*
+# Image-Cache-It
+
+[_Picasso_](http://square.github.io/picasso/) - _Android_
+
+[_SDWebImage_](https://github.com/rs/SDWebImage/) - _IOS_
+
 ## Install
+
 ```
 npm install nativescript-image-cache-it
 ```
+
 ## Usage
 
 ```js
-import {ImageCacheIt} from 'nativescript-image-cache-it';
+import { ImageCacheIt } from 'nativescript-image-cache-it';
 ```
 
 Set image url to load.
+
 ```js
 load = image;
 ```
+
 Set placeholder while images are downloading.
 
 ```js
-placeHolder = "~/assets/images/ph.png";
+placeHolder = '~/assets/images/ph.png';
 ```
+
 Set placeholder for images are that failed to download.
+
 ```js
-errorHolder = "~/assets/images/broken.png";
+errorHolder = '~/assets/images/broken.png';
 ```
+
 Set image size.
+
+_Note:_ Resize should be width then height and split with a `,` (comma).
+
 ```js
-resize = "300 300"
+resize = '300 300';
 ```
+
 Stretch
+
+_Note:_ When using `aspectFit` or `aspectFill` on android you need to provide the `resize` value or set a height/width on the ImageCacheIt instance.
+
 ```js
 stretch = "aspectFit" (optional) aspectFit || aspectFill || fill || none
 ```
+
 e.g
 
 ```js
-import {ImageCacheIt} from 'nativescript-image-cache-it';
- let cache = new ImageCacheIt();
-        cache.imageUri = image;
-        cache.placeHolder = "~/assets/images/broken.png";
-        cache.errorHolder = "~/assets/images/ph.png";
-        cache.resize = "300,300";
-        cache.stretch = "aspectFit";
-        return cache;
+import { ImageCacheIt } from 'nativescript-image-cache-it';
+let cache = new ImageCacheIt();
+cache.imageUri = image;
+cache.placeHolder = '~/assets/images/broken.png';
+cache.errorHolder = '~/assets/images/ph.png';
+cache.resize = '300,300';
+cache.stretch = 'aspectFit';
+return cache;
 ```
+
 Xml markup settings
-``` xml
+
+```xml
 resize="300,300" (optional)
 placeHolder="~/assets/images/ph.png"  (optional)
 errorHolder="~/assets/images/broken.png"  (optional)
@@ -60,11 +80,10 @@ imageUri= "http://screenrant.com/wp-content/uploads/The-Flash-vs-the-Reverse-Fla
 IMPORTANT: Make sure you include xmlns:i="nativescript-image-cache-it" on the Page element
 
 e.g
+
 ```xml
 <i:ImageCacheIt stretch="aspectFit"  resize="300,300" placeHolder="~/assets/images/ph.png" errorHolder="~/assets/images/broken.png" imageUri="http://screenrant.com/wp-content/uploads/The-Flash-vs-the-Reverse-Flash.jpg"/>
 ```
-
-
 
 ### Angular
 
@@ -75,15 +94,12 @@ registerElement('ImageCacheIt', () => require('nativescript-image-cache-it').Ima
 
 #### Repeater
 
-Image |  ImageCacheIt
--------- | ---------
-![image_repeater](screenshots/image_repeater.gif?raw=true) | ![imagecacheit_repeater](screenshots/cache-it_repeater.gif?raw=true)
+| Image                                                      | ImageCacheIt                                                         |
+| ---------------------------------------------------------- | -------------------------------------------------------------------- |
+| ![image_repeater](screenshots/image_repeater.gif?raw=true) | ![imagecacheit_repeater](screenshots/cache-it_repeater.gif?raw=true) |
 
 #### ListView
 
-Image |  ImageCacheIt
--------- | ---------
-![image_listview](screenshots/image_list_view.gif?raw=true) | ![imagecacheit_listview](screenshots/cache-it_list_view.gif?raw=true)
-
-
-
+| Image                                                       | ImageCacheIt                                                          |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| ![image_listview](screenshots/image_list_view.gif?raw=true) | ![imagecacheit_listview](screenshots/cache-it_list_view.gif?raw=true) |

--- a/src/image-cache-it.android.ts
+++ b/src/image-cache-it.android.ts
@@ -220,12 +220,48 @@ export class ImageCacheIt extends ImageCacheItBase {
         )
       );
   }
+
+  /**
+   * Helper method to call the Picasso resize method, which is necessary before centerCrop() and centerInside().
+   * Will use the `resize` value if provided, next is the `height` and `width` of the imageCacheIt instance
+   * last is the parent which is probably not reliable.
+   * Only used when aspectFit or aspectFill are set on the stretch property.
+   */
+  private setAspectResize() {
+    let newSize;
+    if (
+      this.resize &&
+      this.resize !== undefined &&
+      this.resize.split(',').length > 1
+    ) {
+      newSize = {
+        width: parseInt(this.resize.split(',')[0], 10),
+        height: parseInt(this.resize.split(',')[1], 10)
+      };
+    } else if (this.width || this.height) {
+      // use the images height/width (need to be set - more gurds if needed)
+      newSize = {
+        width: parseInt(this.width.toString(), 10),
+        height: parseInt(this.height.toString(), 10)
+      };
+    } else {
+      // use parent size (worth a shot I guess but probably not going to work here reliably)
+      newSize = {
+        width: this.parent.effectiveWidth,
+        height: this.parent.effectiveHeight
+      };
+    }
+
+    this.builder.resize(newSize.width, newSize.height);
+  }
+
   private resetImage(reload = false) {
     if (!this.builder) return;
     switch (this.stretch) {
       case 'aspectFit':
         this.builder = this.picasso.load(this.getImage(this.imageUri));
         this.setBorderAndRadius();
+        this.setAspectResize();
         this.builder.centerInside();
         if (reload) {
           this.builder.into(this.nativeView);
@@ -234,6 +270,7 @@ export class ImageCacheIt extends ImageCacheItBase {
       case 'aspectFill':
         this.builder = this.picasso.load(this.getImage(this.imageUri));
         this.setBorderAndRadius();
+        this.setAspectResize();
         this.builder.centerCrop();
         if (reload) {
           this.builder.into(this.nativeView);

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-image-cache-it",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "Image caching plugin for nativescript",
     "main": "image-cache-it",
     "typings": "index.d.ts",
@@ -41,6 +41,13 @@
         "name": "Osei Fortune",
         "email": "fortune.osei@yahoo.com"
     },
+    "contributors": [
+        {
+            "name": "Brad Martin",
+            "url": "https://github.com/bradmartin",
+            "email": "bmartin@nstudio.io"
+        }
+    ],
     "bugs": {
         "url": "https://github.com/triniwiz/nativescript-image-cache-it/issues"
     },


### PR DESCRIPTION
- Method to exec Picasso `resize` method before `centerCrop` and `centerInside` methods. 
 -- Will use the `resize` values provided or fall back to set `width/height` on ImageCacheIt instance, last try to use parents size.

- adds simple prettierRC to help format consistently on changes, this seemed to align with how the code is already formatted.