### PR TITLE
fixed error with cache clear functionality

### DIFF
--- a/src/image-cache-it.ios.ts
+++ b/src/image-cache-it.ios.ts
@@ -432,8 +432,8 @@ export class ImageCacheIt extends ImageCacheItBase {
         return new Promise((resolve, reject) => {
             const manager = SDWebImageManager.sharedManager;
             if (manager) {
-                manager.clearMemory();
-                manager.clearDiskOnCompletion(() => {
+                manager.imageCache.clearMemory();
+                manager.imageCache.clearDiskOnCompletion(() => {
                     resolve();
                 });
             }
@@ -446,7 +446,7 @@ export class ImageCacheIt extends ImageCacheItBase {
         ImageCacheIt.autoMMCallback = (args) => {
             const manager = SDWebImageManager.sharedManager;
             if (manager) {
-                manager.clearMemory();
+                manager.imageCache.clearMemory();
             }
         };
         app.on(app.lowMemoryEvent as any, ImageCacheIt.autoMMCallback);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ export declare class ImageCacheIt extends ImageCacheItBase {
 
     public static hasItem(src: string): Promise<any>;
 
-    public static clear(src: string): Promise<any>;
+    public static clear(): Promise<any>;
 
     public static enableAutoMM(): void;
 


### PR DESCRIPTION
Using image-cache-it in an Angular NativeScript app. 

Had the issue of the app crashing randomly -> figured out, that the crash happens, when the clearMemory() method is called, so I removed ImageCacheIt.enableAutoMM() from my main.ts file as temporary solution and hadn't any crashes anymore.

After further investigation I found, that also by calling the clear() function I get the error that clearMemory() is not an function - after doing some research I figured, that the function clearMemory() doesn't exist on SDWebImageManager.sharedManager, but on SDWebImageManager.sharedManager.imageCache.

I changed the code and it seems to work well now. 
Hereby I submit the pull request to kindly ask for the changes to be applied to the master repository.