### PR TITLE
fix slow image display performance since dispatch_queue implementation

### DIFF
--- a/src/image-cache-it.ios.ts
+++ b/src/image-cache-it.ios.ts
@@ -96,7 +96,7 @@ export class ImageCacheIt extends ImageCacheItBase {
                                     this._setupFilter(p1);
                                 });
                             } else {
-                                dispatch_async(filter_queue,() => {
+                                dispatch_async(main_queue,() => {
                                     this._setupFilter(p1);
                                 });
                             }


### PR DESCRIPTION
Noticed that since change to dispatch_queue the time till images are displayed increased dramatically.

Found that there is a if query that checks if this.filter and then executes the same code, making the if statement obsolete. My suggestion is to dispatch to the main_queue if this.filter returns false. Tested it with my implementation and had much better performance results.